### PR TITLE
RavenDB-3088 added the ability to limit number of replicated items from ...

### DIFF
--- a/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
+++ b/Raven.Database/Bundles/Replication/Controllers/ReplicationController.cs
@@ -423,7 +423,8 @@ namespace Raven.Database.Bundles.Replication.Controllers
 					{
 						Source = src,
 						ServerInstanceId = localServerInstanceId,
-						LastModified = SystemTime.UtcNow
+						LastModified = SystemTime.UtcNow,
+						MaxNumberOfItemsToReceiveInSingleBatch = Database.Configuration.Replication.MaxNumberOfItemsToReceiveInSingleBatch
 					};
 				}
 				else
@@ -441,6 +442,7 @@ namespace Raven.Database.Bundles.Replication.Controllers
 						sourceReplicationInformation.LastDocumentEtag = Etag.InvalidEtag;
 					}
 
+					sourceReplicationInformation.MaxNumberOfItemsToReceiveInSingleBatch = Database.Configuration.Replication.MaxNumberOfItemsToReceiveInSingleBatch;
 					sourceReplicationInformation.ServerInstanceId = localServerInstanceId;
 				}
 

--- a/Raven.Database/Bundles/Replication/Data/SourceReplicationInformation.cs
+++ b/Raven.Database/Bundles/Replication/Data/SourceReplicationInformation.cs
@@ -21,6 +21,8 @@ namespace Raven.Bundles.Replication.Data
 
 		public DateTime? LastModified { get; set; }
 
+		public int? MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
+
 		public override string ToString()
 		{
 			return string.Format("LastDocumentEtag: {0}, LastAttachmentEtag: {1}", LastDocumentEtag, LastAttachmentEtag);

--- a/Raven.Database/Config/InMemoryRavenConfiguration.cs
+++ b/Raven.Database/Config/InMemoryRavenConfiguration.cs
@@ -283,6 +283,7 @@ namespace Raven.Database.Config
 
 			Replication.FetchingFromDiskTimeoutInSeconds = ravenSettings.Replication.FetchingFromDiskTimeoutInSeconds.Value;
 			Replication.ReplicationRequestTimeoutInMilliseconds = ravenSettings.Replication.ReplicationRequestTimeoutInMilliseconds.Value;
+			Replication.MaxNumberOfItemsToReceiveInSingleBatch = ravenSettings.Replication.MaxNumberOfItemsToReceiveInSingleBatch.Value;
 
             FileSystem.MaximumSynchronizationInterval = ravenSettings.FileSystem.MaximumSynchronizationInterval.Value;
 			FileSystem.DataDirectory = ravenSettings.FileSystem.DataDir.Value;
@@ -1248,6 +1249,11 @@ namespace Raven.Database.Config
 			/// Number of milliseconds before replication requests will timeout. Default: 60 * 1000.
 			/// </summary>
 			public int ReplicationRequestTimeoutInMilliseconds { get; set; }
+
+			/// <summary>
+			/// Maximum number of items replication will receive in single batch. Min: 512. Default: null (let source server decide).
+			/// </summary>
+			public int? MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
 		}
 
         public class FileSystemConfiguration

--- a/Raven.Database/Config/Settings/NullableIntegerSettingWithMin.cs
+++ b/Raven.Database/Config/Settings/NullableIntegerSettingWithMin.cs
@@ -1,0 +1,41 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="NullableIntegerSettingWithMin.cs" company="Hibernating Rhinos LTD">
+//      Copyright (c) Hibernating Rhinos LTD. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace Raven.Database.Config.Settings
+{
+	internal class NullableIntegerSettingWithMin : Setting<int?>
+	{
+		private readonly int minValue;
+
+		public NullableIntegerSettingWithMin(string value, int? defaultValue, int minValue)
+			: base(value, defaultValue)
+		{
+			this.minValue = minValue;
+		}
+
+		public NullableIntegerSettingWithMin(string value, Func<int?> getDefaultValue, int minValue)
+			: base(value, getDefaultValue)
+		{
+			this.minValue = minValue;
+		}
+
+		public override int? Value
+		{
+			get
+			{
+				var val = string.IsNullOrEmpty(value) == false
+						   ? int.Parse(value)
+						   : (getDefaultValue != null ? getDefaultValue() : defaultValue);
+
+				if (val.HasValue) 
+					return Math.Max(minValue, val.Value);
+
+				return val;
+			}
+		}
+	}
+}

--- a/Raven.Database/Config/StronglyTypedRavenSettings.cs
+++ b/Raven.Database/Config/StronglyTypedRavenSettings.cs
@@ -211,6 +211,7 @@ namespace Raven.Database.Config
 
 			Replication.FetchingFromDiskTimeoutInSeconds = new IntegerSetting(settings["Raven/Replication/FetchingFromDiskTimeout"], 30);
 			Replication.ReplicationRequestTimeoutInMilliseconds = new IntegerSetting(settings["Raven/Replication/ReplicationRequestTimeout"], 60 * 1000);
+			Replication.MaxNumberOfItemsToReceiveInSingleBatch = new NullableIntegerSettingWithMin(settings["Raven/Replication/MaxNumberOfItemsToReceiveInSingleBatch"], (int?)null, 512);
 
             FileSystem.MaximumSynchronizationInterval = new TimeSpanSetting(settings[Constants.FileSystem.MaximumSynchronizationInterval], TimeSpan.FromSeconds(60), TimeSpanArgumentType.FromParse);
             FileSystem.IndexStoragePath = new StringSetting(settings[Constants.FileSystem.IndexStorageDirectory], string.Empty);
@@ -419,6 +420,8 @@ namespace Raven.Database.Config
 			public IntegerSetting FetchingFromDiskTimeoutInSeconds { get; set; }
 
 			public IntegerSetting ReplicationRequestTimeoutInMilliseconds { get; set; }
+
+			public NullableIntegerSettingWithMin MaxNumberOfItemsToReceiveInSingleBatch { get; set; }
 		}
 
 		public class FileSystemConfiguration

--- a/Raven.Database/Raven.Database.csproj
+++ b/Raven.Database/Raven.Database.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Actions\QueryActions.cs" />
     <Compile Include="Actions\SubscriptionActions.cs" />
     <Compile Include="Actions\TaskActions.cs" />
+    <Compile Include="Config\Settings\NullableIntegerSettingWithMin.cs" />
     <Compile Include="Indexing\Sorting\Custom\CustomSortField.cs" />
     <Compile Include="Indexing\Sorting\Custom\CustomSortFieldCompartor.cs" />
     <Compile Include="Indexing\Sorting\Custom\IndexEntriesToComparablesGenerator.cs" />


### PR DESCRIPTION
...destination server (Raven/Replication/MaxNumberOfItemsToReceiveInSingleBatch)
