### PR TITLE
RavenDB-19541 Assert in `SelectFields` not in `CreaceQueryInternal` since it's shared with LINQ.

### DIFF
--- a/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AbstractDocumentQuery.cs
@@ -1990,10 +1990,12 @@ Use session.Query<T>() instead of session.Advanced.DocumentQuery<T>. The session
             if (filterLimit is not long.MaxValue)
                 FilterLimit = filterLimit;
         }
-        
-        protected static void ThrowProjectionIsAlreadyDone()
+
+        protected void AssertProjectionIsNotDoneTwice()
         {
-            throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
+            if (FieldsToFetchToken != null && 
+                (FieldsToFetchToken.FieldsToFetch is {Length: > 0} || FieldsToFetchToken.Projections is {Length: > 0}))
+                throw new InvalidOperationException("Projection is already done. You should not project your result twice.");
         }
     }
 }

--- a/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/AsyncDocumentQuery.cs
@@ -569,6 +569,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
+            AssertProjectionIsNotDoneTwice();
             var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             var projections = propertyInfos.Select(x => x.Name).ToArray();
             var fields = propertyInfos.Select(p => p.Name).ToArray();
@@ -598,6 +599,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IAsyncDocumentQuery<TProjection> SelectFields<TProjection>(QueryData queryData)
         {
+            AssertProjectionIsNotDoneTwice();
             queryData.IsProjectInto = true;
             return CreateDocumentQueryInternal<TProjection>(queryData);
         }
@@ -1005,9 +1007,6 @@ namespace Raven.Client.Documents.Session
 
         internal AsyncDocumentQuery<TResult> CreateDocumentQueryInternal<TResult>(QueryData queryData = null)
         {
-            if (FieldsToFetchToken != null && (FieldsToFetchToken.FieldsToFetch is {Length: > 0} || FieldsToFetchToken.Projections is {Length: > 0}))
-                ThrowProjectionIsAlreadyDone();
-
             FieldsToFetchToken newFieldsToFetch;
             if (queryData != null && queryData.Fields.Length > 0)
             {

--- a/src/Raven.Client/Documents/Session/DocumentQuery.cs
+++ b/src/Raven.Client/Documents/Session/DocumentQuery.cs
@@ -39,6 +39,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(ProjectionBehavior projectionBehavior)
         {
+            AssertProjectionIsNotDoneTwice();
             var propertyInfos = ReflectionUtil.GetPropertiesAndFieldsFor<TProjection>(ReflectionUtil.BindingFlagsConstants.QueryingFields).ToList();
             var projections = propertyInfos.Select(x => Conventions.GetConvertedPropertyNameFor(x)).ToArray();
             var fields = propertyInfos.Select(p => Conventions.GetConvertedPropertyNameFor(p)).ToArray();
@@ -117,6 +118,7 @@ namespace Raven.Client.Documents.Session
         /// <inheritdoc />
         public IDocumentQuery<TProjection> SelectFields<TProjection>(QueryData queryData)
         {
+            AssertProjectionIsNotDoneTwice();
             queryData.IsProjectInto = true;
             return CreateDocumentQueryInternal<TProjection>(queryData);
         }
@@ -991,9 +993,6 @@ namespace Raven.Client.Documents.Session
 
         internal DocumentQuery<TResult> CreateDocumentQueryInternal<TResult>(QueryData queryData = null)
         {
-            if (FieldsToFetchToken != null && (FieldsToFetchToken.FieldsToFetch is {Length: > 0} || FieldsToFetchToken.Projections is {Length: > 0}))
-                ThrowProjectionIsAlreadyDone();
-
             FieldsToFetchToken newFieldsToFetch;
             if (queryData != null && queryData.Fields.Length > 0)
             {


### PR DESCRIPTION
Assert in `SelectFields` not in `CreaceQueryInternal` since it's shared with LINQ.
